### PR TITLE
add: support for EGS and gamepass versions

### DIFF
--- a/Pikuniku.asl
+++ b/Pikuniku.asl
@@ -1,6 +1,41 @@
-state("Pikuniku")
+state("Pikuniku", "steam")
 {
     byte load : "UnityPlayer.dll", 0x01466538, 0x38;
+}
+
+state("Pikuniku", "egs")
+{
+    byte load : "UnityPlayer.dll", 0x017F9F88, 0x38;
+}
+
+state("Pikuniku", "gamepass")
+{
+    byte load : "UnityPlayer.dll", 0x01795688, 0x38;
+}
+
+init
+{
+
+    long dllSize = 0; // The size of UnityPlayer.dll
+    long exeSize = 0; // The size of Pikuniku.exe
+
+    for (int i = 0; i < modules.Length; i++) {
+        if (modules[i].ModuleName == "Pikuniku.exe") {
+            exeSize = modules[i].ModuleMemorySize;
+        } else if (modules[i].ModuleName == "UnityPlayer.dll") {
+            dllSize = modules[i].ModuleMemorySize;
+        }
+    }
+
+    if (exeSize == 667648 && dllSize == 26787840) {
+        // EGS 1.1
+        version = "egs";
+    } else if (exeSize == 667648 && dllSize == 26353664) {
+        // Gamepass 1.0.5
+        version = "gamepass";
+    } else {
+        version = "steam";
+    }
 }
 
 startup


### PR DESCRIPTION
Found some similar pointer paths for EGS (1.1) and gamepass (1.0.5) versions. Minimal testing has been done. (requested via discord by Austamate)

This splitter detects the version of the game by checking the module size of `Pikuniku.exe` and `UnityPlayer.dll`. It will use the respective pointer paths when EGS and Gamepass version is detected; for everything else, it should behave exactly like the previous splitter.